### PR TITLE
Fix path concatenation in prefixURL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
-import path from 'path';
 import React from 'react';
 import NextLink from 'next/link';
 import getConfig from 'next/config';
 
 const { publicRuntimeConfig } = getConfig();
 
-export const prefixURL = url => path.join(publicRuntimeConfig.assetPrefix, url);
+export const prefixURL = url => publicRuntimeConfig.assetPrefix.replace(/\/+$/, '') + '/' + url.replace(/^\/+/, '');
 
 export const Image = props => <img {...props} src={prefixURL(props.src)} />;
 


### PR DESCRIPTION
The `path` module will behave differently on Windows (it will join with `\`).

This change replaces the usage of `path` for a tiny custom `.replace()` call to correctly concatenate URL paths.