### PR TITLE
Support object syntax for hrefs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,14 @@ import getConfig from 'next/config';
 
 const { publicRuntimeConfig } = getConfig();
 
-export const prefixURL = url => /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(url) ? url : (
-  publicRuntimeConfig.assetPrefix.replace(/\/+$/, '') + '/' + url.replace(/^\/+/, '')
+const prefixPath = path => publicRuntimeConfig.assetPrefix.replace(/\/+$/, '') + '/' + (path || '').replace(/^\/+/, '')
+
+export const prefixURL = url => {
+  if (typeof url === 'object') {
+    return { ...url, pathname: prefixPath(url.pathname) };
+  } else {
+    return /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(url) ? url : prefixPath(url);
+  }
 );
 
 export const Image = props => <img {...props} src={prefixURL(props.src)} />;


### PR DESCRIPTION
Next.js allows [passing an object as a href](https://github.com/zeit/next.js#with-url-object), this change adds transparent support for that.